### PR TITLE
feat: consider base url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/node_modules/
+/.idea/
+/.vscode/
+yarn.lock
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /node_modules/
 /.idea/
 /.vscode/
+/coverage/
 yarn.lock
 package-lock.json

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -1,0 +1,187 @@
+const {create} = require('../strict-dependencies')
+const path = require('path')
+const resolveImportPath = require('../strict-dependencies/resolveImportPath')
+
+jest.mock('../strict-dependencies/resolveImportPath')
+
+describe('create', () => {
+  it('should return object', () => {
+    const created = create({options: [[]]})
+    expect(typeof created).toBe('object')
+    expect(created).toHaveProperty('ImportDeclaration')
+  })
+})
+
+describe('create.ImportDeclaration', () => {
+  it('should do nothing if no dependencies', () => {
+    resolveImportPath.mockReturnValue('src/components/ui/Text')
+    const getFilename = jest.fn(() => path.join(process.cwd(), 'src/components/aaa/bbb.ts'))
+    const report = jest.fn()
+    const {ImportDeclaration: checkImport} = create({
+      options: [[]],
+      getFilename,
+      report,
+    })
+
+    checkImport({source: {value: '@/components/ui/Text'}})
+
+    expect(getFilename).toBeCalledTimes(1)
+    expect(report).not.toBeCalled()
+  })
+
+  it('should do nothing if not matched with importPath', () => {
+    // importPath: src/components/ui/Text
+    // dependency.module: src/libs
+
+    resolveImportPath.mockReturnValue('src/components/ui/Text')
+    const getFilename = jest.fn(() => path.join(process.cwd(), 'src/components/aaa/bbb.ts'))
+    const report = jest.fn()
+    const {ImportDeclaration: checkImport} = create({
+      options: [
+        [{module: 'src/libs'}],
+      ],
+      getFilename,
+      report,
+    })
+
+    checkImport({source: {value: '@/components/ui/Tex'}})
+
+    expect(getFilename).toBeCalledTimes(1)
+    expect(report).not.toBeCalled()
+  })
+
+  it('should not report if allowed', () => {
+    // relativePath: src/components/pages/aaa.ts
+    // importPath: src/components/ui/Text
+    // dependency.module: src/components/ui, dependency.allowReferenceFrom: ['src/components/pages'], allowSameModule: true
+
+    resolveImportPath.mockReturnValue('src/components/ui/Text')
+    const getFilename = jest.fn(() => path.join(process.cwd(), 'src/components/pages/aaa.ts'))
+    const report = jest.fn()
+    const {ImportDeclaration: checkImport} = create({
+      options: [
+        [{module: 'src/components/ui', allowReferenceFrom: ['src/components/pages'], allowSameModule: true}],
+      ],
+      getFilename,
+      report,
+    })
+
+    checkImport({source: {value: '@/components/ui/Text'}})
+
+    expect(getFilename).toBeCalledTimes(1)
+    expect(report).not.toBeCalled()
+  })
+
+  it('should not report if allowed with glob pattern', () => {
+    // relativePath: src/components/pages/aaa.ts
+    // importPath: src/components/ui/Text
+    // dependency.module: src/components/ui, dependency.allowReferenceFrom: ['src/components/**/*.ts'], allowSameModule: true
+
+    resolveImportPath.mockReturnValue('src/components/ui/Text')
+    const getFilename = jest.fn(() => path.join(process.cwd(), 'src/components/pages/aaa.ts'))
+    const report = jest.fn()
+    const {ImportDeclaration: checkImport} = create({
+      options: [
+        [{module: 'src/components/ui', allowReferenceFrom: ['src/components/**/*.ts'], allowSameModule: true}],
+      ],
+      getFilename,
+      report,
+    })
+
+    checkImport({source: {value: '@/components/ui/Text'}})
+
+    expect(getFilename).toBeCalledTimes(1)
+    expect(report).not.toBeCalled()
+  })
+
+  it('should report if not allowed', () => {
+    // relativePath: src/components/test/aaa.ts
+    // importPath: src/components/ui/Text
+    // dependency.module: src/components/ui, dependency.allowReferenceFrom: ['src/components/pages'], allowSameModule: true
+
+    resolveImportPath.mockReturnValue('src/components/ui/Text')
+    const getFilename = jest.fn(() => path.join(process.cwd(), 'src/components/test/aaa.ts'))
+    const report = jest.fn()
+    const {ImportDeclaration: checkImport} = create({
+      options: [
+        [{module: 'src/components/ui', allowReferenceFrom: ['src/components/pages'], allowSameModule: true}],
+      ],
+      getFilename,
+      report,
+    })
+
+    checkImport({source: {value: '@/components/ui/Text'}})
+
+    expect(getFilename).toBeCalledTimes(1)
+    expect(report.mock.calls).toHaveLength(1)
+    expect(report.mock.calls[0][1]).toBe('import \'src/components/ui/Text\' is not allowed from src/components/test/aaa.ts.')
+  })
+
+  it('should report if not allowed with glob pattern', () => {
+    // relativePath: src/components/test/aaa.tsx
+    // importPath: src/components/ui/Text
+    // dependency.module: src/components/ui, dependency.allowReferenceFrom: ['src/components/**/*.ts'], allowSameModule: true
+
+    resolveImportPath.mockReturnValue('src/components/ui/Text')
+    const getFilename = jest.fn(() => path.join(process.cwd(), 'src/components/test/aaa.tsx'))
+    const report = jest.fn()
+    const {ImportDeclaration: checkImport} = create({
+      options: [
+        [{module: 'src/components/ui', allowReferenceFrom: ['src/components/**/*.ts'], allowSameModule: true}],
+      ],
+      getFilename,
+      report,
+    })
+
+    checkImport({source: {value: '@/components/ui/Text'}})
+
+    expect(getFilename).toBeCalledTimes(1)
+    expect(report.mock.calls).toHaveLength(1)
+    expect(report.mock.calls[0][1]).toBe('import \'src/components/ui/Text\' is not allowed from src/components/test/aaa.tsx.')
+  })
+
+  it('should not report if allowed from same module', () => {
+    // relativePath: src/components/pages/aaa.ts
+    // importPath: src/components/ui/Text
+    // dependency.module: src/components/ui, dependency.allowReferenceFrom: ['src/components/pages'], allowSameModule: true
+
+    resolveImportPath.mockReturnValue('src/components/ui/Text')
+    const getFilename = jest.fn(() => path.join(process.cwd(), 'src/components/ui/aaa.ts'))
+    const report = jest.fn()
+    const {ImportDeclaration: checkImport} = create({
+      options: [
+        [{module: 'src/components/ui', allowReferenceFrom: ['src/aaa'], allowSameModule: true}],
+      ],
+      getFilename,
+      report,
+    })
+
+    checkImport({source: {value: '@/components/ui/Text'}})
+
+    expect(getFilename).toBeCalledTimes(1)
+    expect(report).not.toBeCalled()
+  })
+
+  it('should report if not allowed from same module', () => {
+    // relativePath: src/components/pages/aaa.ts
+    // importPath: src/components/ui/Text
+    // dependency.module: src/components/ui, dependency.allowReferenceFrom: ['src/components/pages'], allowSameModule: true
+
+    resolveImportPath.mockReturnValue('src/components/ui/Text')
+    const getFilename = jest.fn(() => path.join(process.cwd(), 'src/components/ui/aaa.ts'))
+    const report = jest.fn()
+    const {ImportDeclaration: checkImport} = create({
+      options: [
+        [{module: 'src/components/ui', allowReferenceFrom: ['src/aaa'], allowSameModule: false}],
+      ],
+      getFilename,
+      report,
+    })
+
+    checkImport({source: {value: '@/components/ui/Text'}})
+
+    expect(getFilename).toBeCalledTimes(1)
+    expect(report.mock.calls).toHaveLength(1)
+    expect(report.mock.calls[0][1]).toBe('import \'src/components/ui/Text\' is not allowed from src/components/ui/aaa.ts.')
+  })
+})

--- a/__tests__/resolveImportPath.js
+++ b/__tests__/resolveImportPath.js
@@ -4,6 +4,14 @@ const {readFileSync} = require('fs')
 jest.mock('fs')
 
 describe('resolveImportPath', () => {
+  it('should resolve relative path', () => {
+    // > src/pages/aaa/bbb.ts
+    // import Text from '../../components/ui/Text'
+
+    readFileSync.mockReturnValue(JSON.stringify({}))
+    expect(resolveImportPath('../../components/ui/Text')).toBe('src/components/ui/Text')
+  })
+
   it('should do nothing if tsconfig.json does not exist', () => {
     readFileSync.mockImplementation(() => {
       throw new Error()

--- a/__tests__/resolveImportPath.js
+++ b/__tests__/resolveImportPath.js
@@ -9,19 +9,19 @@ describe('resolveImportPath', () => {
     // import Text from '../../components/ui/Text'
 
     readFileSync.mockReturnValue(JSON.stringify({}))
-    expect(resolveImportPath('../../components/ui/Text')).toBe('src/components/ui/Text')
+    expect(resolveImportPath('../../components/ui/Text', 'src/pages/aaa/bbb.ts')).toBe('src/components/ui/Text')
   })
 
   it('should do nothing if tsconfig.json does not exist', () => {
     readFileSync.mockImplementation(() => {
       throw new Error()
     })
-    expect(resolveImportPath('components/aaa/bbb')).toBe('components/aaa/bbb')
+    expect(resolveImportPath('components/aaa/bbb', 'src/pages/aaa/bbb.ts')).toBe('components/aaa/bbb')
   })
 
   it('should do nothing if no paths setting', () => {
     readFileSync.mockReturnValue(JSON.stringify({}))
-    expect(resolveImportPath('components/aaa/bbb')).toBe('components/aaa/bbb')
+    expect(resolveImportPath('components/aaa/bbb', 'src/pages/aaa/bbb.ts')).toBe('components/aaa/bbb')
   })
 
   it('should resolve tsconfig paths', () => {
@@ -33,8 +33,8 @@ describe('resolveImportPath', () => {
       },
     }))
 
-    expect(resolveImportPath('components/aaa/bbb')).toBe('components/aaa/bbb')
-    expect(resolveImportPath('@/components/aaa/bbb')).toBe('components/aaa/bbb')
+    expect(resolveImportPath('components/aaa/bbb', 'src/pages/aaa/bbb.ts')).toBe('components/aaa/bbb')
+    expect(resolveImportPath('@/components/aaa/bbb', 'src/pages/aaa/bbb.ts')).toBe('components/aaa/bbb')
   })
 
   describe('should resolve tsconfig paths with baseUrl', () => {
@@ -49,8 +49,8 @@ describe('resolveImportPath', () => {
           },
         }))
 
-        expect(resolveImportPath('components/aaa/bbb')).toBe('components/aaa/bbb')
-        expect(resolveImportPath('@/components/aaa/bbb')).toBe('src/components/aaa/bbb')
+        expect(resolveImportPath('components/aaa/bbb', 'src/pages/aaa/bbb.ts')).toBe('components/aaa/bbb')
+        expect(resolveImportPath('@/components/aaa/bbb', 'src/pages/aaa/bbb.ts')).toBe('src/components/aaa/bbb')
       })
     })
   })

--- a/__tests__/resolveImportPath.js
+++ b/__tests__/resolveImportPath.js
@@ -1,0 +1,49 @@
+const resolveImportPath = require('../strict-dependencies/resolveImportPath')
+const {readFileSync} = require('fs')
+
+jest.mock('fs')
+
+describe('resolveImportPath', () => {
+  it('should do nothing if tsconfig.json does not exist', () => {
+    readFileSync.mockImplementation(() => {
+      throw new Error()
+    })
+    expect(resolveImportPath('components/aaa/bbb')).toBe('components/aaa/bbb')
+  })
+
+  it('should do nothing if no paths setting', () => {
+    readFileSync.mockReturnValue(JSON.stringify({}))
+    expect(resolveImportPath('components/aaa/bbb')).toBe('components/aaa/bbb')
+  })
+
+  it('should resolve tsconfig paths', () => {
+    readFileSync.mockReturnValue(JSON.stringify({
+      compilerOptions: {
+        paths: {
+          '@/components/': ['components/'],
+        },
+      },
+    }))
+
+    expect(resolveImportPath('components/aaa/bbb')).toBe('components/aaa/bbb')
+    expect(resolveImportPath('@/components/aaa/bbb')).toBe('components/aaa/bbb')
+  })
+
+  describe('should resolve tsconfig paths with baseUrl', () => {
+    ['src', './src', 'src/'].forEach(baseUrl => {
+      it(baseUrl, () => {
+        readFileSync.mockReturnValue(JSON.stringify({
+          compilerOptions: {
+            baseUrl,
+            paths: {
+              '@/components/': ['components/'],
+            },
+          },
+        }))
+
+        expect(resolveImportPath('components/aaa/bbb')).toBe('components/aaa/bbb')
+        expect(resolveImportPath('@/components/aaa/bbb')).toBe('src/components/aaa/bbb')
+      })
+    })
+  })
+})

--- a/package.json
+++ b/package.json
@@ -11,5 +11,13 @@
   "files": [
     "strict-dependencies",
     "index.js"
-  ]
+  ],
+  "devDependencies": {
+    "is-glob": "^4.0.3",
+    "jest": "^27.2.4",
+    "micromatch": "^4.0.4"
+  },
+  "scripts": {
+    "test": "jest --coverage"
+  }
 }

--- a/strict-dependencies/index.js
+++ b/strict-dependencies/index.js
@@ -51,7 +51,7 @@ module.exports = {
     function checkImport(node) {
       const fileFullPath = context.getFilename()
       const relativeFilePath = path.relative(process.cwd(), fileFullPath)
-      const importPath = resolveImportPath(node.source.value)
+      const importPath = resolveImportPath(node.source.value, relativeFilePath)
 
       dependencies
         .filter((dependency) => isMatch(importPath, dependency.module))

--- a/strict-dependencies/index.js
+++ b/strict-dependencies/index.js
@@ -64,7 +64,7 @@ module.exports = {
             (dependency.allowSameModule && isMatch(relativeFilePath, dependency.module))
 
           if (!isAllowed) {
-            context.report(node, `import '${importPath}' is not allowed from ${dependency.module}.`)
+            context.report(node, `import '${importPath}' is not allowed from ${relativeFilePath}.`)
           }
         })
     }

--- a/strict-dependencies/resolveImportPath.js
+++ b/strict-dependencies/resolveImportPath.js
@@ -19,7 +19,7 @@ module.exports = (importPath) => {
     if (tsConfig.compilerOptions && tsConfig.compilerOptions.paths) {
       Object.keys(tsConfig.compilerOptions.paths).forEach((key) => {
         // FIXME: このlint ruleではimport先が存在するかチェックしておらず、複数のパスから正しい方を選択できないため[0]固定
-        importAliasMap[key] = tsConfig.compilerOptions.paths[key][0]
+        importAliasMap[key] = `${tsConfig.compilerOptions.baseUrl ? `${tsConfig.compilerOptions.baseUrl.replace(/^(\.\/)?(.+?)\/?$/, '$2')}/` : ''}${tsConfig.compilerOptions.paths[key][0]}`
       })
     }
   } catch (e) {

--- a/strict-dependencies/resolveImportPath.js
+++ b/strict-dependencies/resolveImportPath.js
@@ -6,7 +6,7 @@ const path = require('path')
 /**
  * import文のrootからのパスを求める
  */
-module.exports = (importPath) => {
+module.exports = (importPath, relativeFilePath) => {
   // { [importAlias: string]: OriginalPath }
   const importAliasMap = {}
 
@@ -24,6 +24,10 @@ module.exports = (importPath) => {
     }
   } catch (e) {
     // DO NOTHING
+  }
+
+  if (importPath.startsWith('./') || importPath.startsWith('../')) {
+    importPath = path.join(path.dirname(relativeFilePath), importPath)
   }
 
   return Object.keys(importAliasMap).reduce((resolvedImportPath, key) => {


### PR DESCRIPTION
## 概要

* テスト追加
* tsconfig で paths を考慮する際に baseUrl も考慮するように修正(closes #3)
* 相対パスの import を考慮
* report のメッセージの修正

## 詳細

### 相対パスの import を考慮

`src/pages/aaa/bbb.ts` ファイルから 

```ts
import Text from '../../components/ui/Text'
```

で import したときに importPath はそのまま `../../components/ui/Text` になってしまう。
path.join 等でパスを解決すると `src/components/ui/Text` となり、`"module": "src/components/ui"` などと match するようになる
あえて `../../components/ui` を module に指定することも考えられるが通常の利用者が想定している動作ではないと考えたので修正

### report のメッセージの修正

特定のファイル内からの使用が許可されていない旨を伝える必要があるため修正

```diff
- context.report(node, `import '${importPath}' is not allowed from ${dependency.module}.`)
+ context.report(node, `import '${importPath}' is not allowed from ${relativeFilePath}.`)
```

例：
`src/lib/aaa.tsx` から `src/components/ui` module の定義で許可されていない `src/components/ui/Text` を import した場合

```
Error: import 'src/components/ui/Text' is not allowed from src/components/ui.
```
↓
```
Error: import 'src/components/ui/Text' is not allowed from src/lib/aaa.tsx.
```

