### PR TITLE
Windows 環境での名前解決の失敗の修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "is-glob": "^4.0.3",
     "micromatch": "^4.0.4",
+    "normalize-path": "^3.0.0",
     "require-strip-json-comments": "^2.0.0"
   },
   "devDependencies": {

--- a/strict-dependencies/index.js
+++ b/strict-dependencies/index.js
@@ -3,6 +3,7 @@
 const path = require('path')
 const mm = require('micromatch')
 const isGlob = require('is-glob')
+const normalize = require('normalize-path')
 
 const resolveImportPath = require('./resolveImportPath')
 
@@ -60,7 +61,7 @@ module.exports = {
 
     function checkImport(node) {
       const fileFullPath = context.getFilename()
-      const relativeFilePath = path.relative(process.cwd(), fileFullPath)
+      const relativeFilePath = normalize(path.relative(process.cwd(), fileFullPath))
       const importPath = resolveImportPath(node.source.value, resolveRelativeImport ? relativeFilePath : null)
 
       dependencies

--- a/strict-dependencies/resolveImportPath.js
+++ b/strict-dependencies/resolveImportPath.js
@@ -2,6 +2,7 @@
 
 const path = require('path')
 const parseJSON = require('require-strip-json-comments')
+const normalize = require('normalize-path')
 
 /**
  * import文のrootからのパスを求める
@@ -30,8 +31,10 @@ module.exports = (importPath, relativeFilePath) => {
     importPath = path.join(path.dirname(relativeFilePath), importPath)
   }
 
-  return Object.keys(importAliasMap).reduce((resolvedImportPath, key) => {
+  const absolutePath = Object.keys(importAliasMap).reduce((resolvedImportPath, key) => {
     // FIXME: use glob module instead of replace('*')
     return resolvedImportPath.replace(key.replace('*', ''), importAliasMap[key].replace('*', ''))
   }, importPath)
+
+  return normalize(absolutePath)
 }


### PR DESCRIPTION
## 概要

* Windows 環境で、`allowSameModule` などが正しく動作していなかった問題の修正

## 詳細

* Windows 環境において、 eslintrc に指定したパス (`a/b/c/component`) と実際に取得されたパス (`a\b\c\component`) との不一致で、偽陽性が発生していた
* `normalize-path` を通すことで、 Windows とその他の環境での動作の不一致をなくした