### PR TITLE
tsconfigのpathsに全てのpathに一致する指定があった場合に動作するよう修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,20 @@ npm install eslint-plugin-strict-dependencies --save-dev
      - `resolveRelativeImport = false`: Resolve as `./bbb` (excluded from lint target)
      - `resolveRelativeImport = true`:  Resolve as `src/components/bbb`: (included from lint target)
 
+- pathIndexMap: `object[default = null]`
+  - In eslint-plugin-strict-dependencies, path alias resolution is performed based on the paths specified in the tsconfig.
+  - By default, the value with an index number of `0` is used, but you can specify an option to use a value with any index number.
+  - Specify it as in the following example:
+    - `tsconfig.json`
+      ```json
+      {
+        "compilerOptions": {
+            "*": ["aaa/*", "bbb/*"]
+          },
+      }
+      ```
+    - `pathIndexMap = { "*": 1 } `: `"bbb/*"` is used.
+
 ## Usage
 
 .eslintrc:
@@ -74,6 +88,7 @@ npm install eslint-plugin-strict-dependencies --save-dev
     // options
     // {
     //   "resolveRelativeImport": true
+    //   "pathIndexMap": { "*": 1 }
     // }
   ]
 }

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -200,7 +200,7 @@ describe('create.ImportDeclaration', () => {
 
     checkImport({source: {value: '@/components/ui/Text'}})
 
-    expect(resolveImportPath).toBeCalledWith('@/components/ui/Text', 'src/components/ui/aaa.ts')
+    expect(resolveImportPath).toBeCalledWith('@/components/ui/Text', 'src/components/ui/aaa.ts', {})
     expect(getFilename).toBeCalledTimes(1)
     expect(report).not.toBeCalled()
   })
@@ -219,7 +219,7 @@ describe('create.ImportDeclaration', () => {
 
     checkImport({source: {value: '@/components/ui/Text'}})
 
-    expect(resolveImportPath).toBeCalledWith('@/components/ui/Text', null)
+    expect(resolveImportPath).toBeCalledWith('@/components/ui/Text', null, {})
     expect(getFilename).toBeCalledTimes(1)
     expect(report).not.toBeCalled()
   })

--- a/__tests__/resolveImportPath.js
+++ b/__tests__/resolveImportPath.js
@@ -9,7 +9,7 @@ describe('resolveImportPath', () => {
     // import Text from '../../components/ui/Text'
 
     readFileSync.mockReturnValue(JSON.stringify({}))
-    expect(resolveImportPath('../../components/ui/Text', 'src/pages/aaa/bbb.ts')).toBe('src/components/ui/Text')
+    expect(resolveImportPath('../../components/ui/Text', 'src/pages/aaa/bbb.ts', {})).toBe('src/components/ui/Text')
   })
 
   it('should not resolve relative path if relativeFilePath is empty', () => {
@@ -17,19 +17,19 @@ describe('resolveImportPath', () => {
     // import Text from '../../components/ui/Text'
 
     readFileSync.mockReturnValue(JSON.stringify({}))
-    expect(resolveImportPath('../../components/ui/Text', null)).toBe('../../components/ui/Text')
+    expect(resolveImportPath('../../components/ui/Text', null, {})).toBe('../../components/ui/Text')
   })
 
   it('should do nothing if tsconfig.json does not exist', () => {
     readFileSync.mockImplementation(() => {
       throw new Error()
     })
-    expect(resolveImportPath('components/aaa/bbb', null)).toBe('components/aaa/bbb')
+    expect(resolveImportPath('components/aaa/bbb', null, {})).toBe('components/aaa/bbb')
   })
 
   it('should do nothing if no paths setting', () => {
     readFileSync.mockReturnValue(JSON.stringify({}))
-    expect(resolveImportPath('components/aaa/bbb', null)).toBe('components/aaa/bbb')
+    expect(resolveImportPath('components/aaa/bbb', null, {})).toBe('components/aaa/bbb')
   })
 
   describe('should resolve tsconfig paths', () => {
@@ -47,8 +47,8 @@ describe('resolveImportPath', () => {
           },
         }))
 
-        expect(resolveImportPath('components/aaa/bbb', null)).toBe('components/aaa/bbb')
-        expect(resolveImportPath('@/components/aaa/bbb', null)).toBe(expected)
+        expect(resolveImportPath('components/aaa/bbb', null, {})).toBe('components/aaa/bbb')
+        expect(resolveImportPath('@/components/aaa/bbb', null, {})).toBe(expected)
       })
     })
   })
@@ -73,8 +73,8 @@ describe('resolveImportPath', () => {
           },
         }))
 
-        expect(resolveImportPath('components/aaa/bbb', null)).toBe('components/aaa/bbb')
-        expect(resolveImportPath('@/components/aaa/bbb', null)).toBe(expected)
+        expect(resolveImportPath('components/aaa/bbb', null, {})).toBe('components/aaa/bbb')
+        expect(resolveImportPath('@/components/aaa/bbb', null, {})).toBe(expected)
       })
     })
   })

--- a/__tests__/resolveImportPath.js
+++ b/__tests__/resolveImportPath.js
@@ -78,4 +78,29 @@ describe('resolveImportPath', () => {
       })
     })
   })
+
+  describe('resolveImportPath with pathIndexMap parameter', () => {
+    const tsConfigWithMultiplePaths = JSON.stringify({
+      compilerOptions: {
+        paths: {
+          '@/components/*': ['src/components/*', 'src/alternativeComponents/*'],
+        },
+      },
+    });
+
+    it('should resolve path alias with specified index in pathIndexMap', () => {
+      readFileSync.mockReturnValue(tsConfigWithMultiplePaths);
+      expect(resolveImportPath('@/components/aaa/bbb', null, { '@/components/*': 1 })).toBe('src/alternativeComponents/aaa/bbb');
+    });
+  
+    it('should resolve path alias with default index:0 if specified index does not exist', () => {
+      readFileSync.mockReturnValue(tsConfigWithMultiplePaths);
+      expect(resolveImportPath('@/components/aaa/bbb', null, { '@/components/*': 5 })).toBe('src/components/aaa/bbb');
+    });
+  
+    it('should resolve path alias with default index:0 if pathIndexMap is an empty object', () => {
+      readFileSync.mockReturnValue(tsConfigWithMultiplePaths);
+      expect(resolveImportPath('@/components/aaa/bbb', null, {})).toBe('src/components/aaa/bbb');
+    });
+  })
 })

--- a/strict-dependencies/index.js
+++ b/strict-dependencies/index.js
@@ -49,6 +49,9 @@ module.exports = {
         properties: {
           resolveRelativeImport: {
             type: 'boolean',
+          },
+          pathIndexMap: {
+            type: 'object'
           }
         },
       },
@@ -58,11 +61,12 @@ module.exports = {
     const dependencies = context.options[0]
     const options = context.options.length > 1 ? context.options[1] : {}
     const resolveRelativeImport = options.resolveRelativeImport
+    const pathIndexMap = options.pathIndexMap ? options.pathIndexMap : {}
 
     function checkImport(node) {
       const fileFullPath = context.getFilename()
       const relativeFilePath = normalize(path.relative(process.cwd(), fileFullPath))
-      const importPath = resolveImportPath(node.source.value, resolveRelativeImport ? relativeFilePath : null)
+      const importPath = resolveImportPath(node.source.value, resolveRelativeImport ? relativeFilePath : null, pathIndexMap)
 
       dependencies
         .filter((dependency) => isMatch(importPath, dependency.module))

--- a/strict-dependencies/resolveImportPath.js
+++ b/strict-dependencies/resolveImportPath.js
@@ -22,7 +22,7 @@ module.exports = (importPath, relativeFilePath, pathIndexMap) => {
         const matchedKey = Object.keys(pathIndexMap).find(k => k === key)
         // MEMO: pathIndexMapの指定がない場合 or 指定されているindexにアクセスしても値が得られない場合は[0]固定
         const pathIndex = matchedKey ? pathIndexMap[matchedKey] : 0
-        const pathValue = tsConfig.compilerOptions.paths[key][pathIndex] ? tsConfig.compilerOptions.paths[key][pathIndex] : tsConfig.compilerOptions.paths[key][0]
+        const pathValue = tsConfig.compilerOptions.paths[key][pathIndex] ?? tsConfig.compilerOptions.paths[key][0]
         importAliasMap[key] = tsConfig.compilerOptions.baseUrl ? path.join(tsConfig.compilerOptions.baseUrl, pathValue) : pathValue
       })
     }

--- a/strict-dependencies/resolveImportPath.js
+++ b/strict-dependencies/resolveImportPath.js
@@ -19,6 +19,11 @@ module.exports = (importPath, relativeFilePath) => {
     const tsConfig = parseJSON(tsConfigFilePath)
     if (tsConfig.compilerOptions && tsConfig.compilerOptions.paths) {
       Object.keys(tsConfig.compilerOptions.paths).forEach((key) => {
+        if(key === '*'){
+          importAliasMap[key] = ''
+          return
+        }
+
         // FIXME: このlint ruleではimport先が存在するかチェックしておらず、複数のパスから正しい方を選択できないため[0]固定
         importAliasMap[key] = tsConfig.compilerOptions.baseUrl ? path.join(tsConfig.compilerOptions.baseUrl, tsConfig.compilerOptions.paths[key][0]) : tsConfig.compilerOptions.paths[key][0]
       })

--- a/strict-dependencies/resolveImportPath.js
+++ b/strict-dependencies/resolveImportPath.js
@@ -20,6 +20,7 @@ module.exports = (importPath, relativeFilePath, pathIndexMap) => {
     if (tsConfig.compilerOptions && tsConfig.compilerOptions.paths) {
       Object.keys(tsConfig.compilerOptions.paths).forEach((key) => {
         const matchedKey = Object.keys(pathIndexMap).find(k => k === key)
+        // MEMO: pathIndexMapの指定がない場合 or 指定されているindexにアクセスしても値が得られない場合は[0]固定
         const pathIndex = matchedKey ? pathIndexMap[matchedKey] : 0
         const pathValue = tsConfig.compilerOptions.paths[key][pathIndex] ? tsConfig.compilerOptions.paths[key][pathIndex] : tsConfig.compilerOptions.paths[key][0]
         importAliasMap[key] = tsConfig.compilerOptions.baseUrl ? path.join(tsConfig.compilerOptions.baseUrl, pathValue) : pathValue


### PR DESCRIPTION
### 概要
tsconfigのpaths に下記のような指定があった場合にプラグインが正常に動作していないため修正しました。
```json
{
  "compilerOptions": {
      "*": ["@types/*", "./*"]
    },
}
```

### 詳細
既にFIXMEコメントがあるので恐縮ですが、下記の処理でindex:0の値が利用されているためと思われます🙇‍♂️
```js
if (tsConfig.compilerOptions && tsConfig.compilerOptions.paths) {
  Object.keys(tsConfig.compilerOptions.paths).forEach((key) => {
    // FIXME: このlint ruleではimport先が存在するかチェックしておらず、複数のパスから正しい方を選択できないため[0]固定
    importAliasMap[key] = tsConfig.compilerOptions.baseUrl ? path.join(tsConfig.compilerOptions.baseUrl, tsConfig.compilerOptions.paths[key][0]) : tsConfig.compilerOptions.paths[key][0]
  })
}
```


概要に記載したtsconfigの場合、absolutePath全ての先頭に@types/が文字列結合される形となります。
そのため初歩的な対処ですがifを追加しました。

（取り急ぎの対応なので細かい挙動のチェックなどはできておらず自身の環境でとりあえず動くという感じなのでマージに至らずともご共有になれば幸いです🙇‍♂️