### PR TITLE
feat: importされる変数・型名等で判定できるimportedMembersオプションの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # eslint-plugin-strict-dependencies
 
-ESlint plugin to define custom module dependency rules.
+ESLint plugin to define custom module dependency rules.
 
 NOTE: `eslint-plugin-strict-dependencies` uses tsconfig, tsconfig.json must be present.
 
@@ -14,7 +14,10 @@ npm install eslint-plugin-strict-dependencies --save-dev
 
 - strict-dependencies
   - module: `string` (Glob or Forward matching string)
-    - target module path
+    - Target module path
+  - targetMembers: `string[]`
+    - Target member name
+    - e.x. `["Suspense"]` in `import { Suspense } from 'react'`
   - allowReferenceFrom: `string[]` (Glob or Forward matching string)
     - Paths of files where target module imports are allowed.
   - allowSameModule: `boolean`
@@ -84,6 +87,17 @@ npm install eslint-plugin-strict-dependencies --save-dev
         "allowReferenceFrom": ["src/libs/router.ts"],
         "allowSameModule": false
       },
+
+      /**
+       * example:
+       * Disallow to import Suspense from react. it should always be imported using `libs/react.ts`.
+       */
+        {
+            "module": "react",
+            "targetMembers": ["Suspense"],
+            "allowReferenceFrom": ["src/libs/react.ts"],
+            "allowSameModule": false
+        },
     ],
     // options
     // {

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -298,7 +298,7 @@ describe('create.ImportDeclaration', () => {
     expect(report).not.toBeCalled()
   })
 
-  it('should report if allowed specifier from target module', () => {
+  it('should report if not allowed specifier from target module', () => {
     // relativePath: src/components/pages/aaa.ts
     // importPath: src/components/ui/Text
     // dependency.module: src/components/ui, dependency.imported: ['Text'], dependency.allowReferenceFrom: ['src/components/pages'], allowSameModule: true
@@ -327,6 +327,37 @@ describe('create.ImportDeclaration', () => {
     expect(getFilename).toBeCalledTimes(1)
     expect(report.mock.calls).toHaveLength(1)
     expect(report.mock.calls[0][1]).toBe('import specifier \'Text\' is not allowed from src/components/button.tsx.')
+  })
+
+  it('should not report if only allowed specifier from target module', () => {
+    // relativePath: src/components/pages/aaa.ts
+    // importPath: src/components/ui/Text
+    // dependency.module: src/components/ui, dependency.imported: ['Text'], dependency.allowReferenceFrom: ['src/components/pages'], allowSameModule: true
+
+    resolveImportPath.mockReturnValue('src/components/ui/Text')
+    const getFilename = jest.fn(() =>
+      path.join(process.cwd(), 'src/components/button.tsx')
+    )
+    const report = jest.fn()
+    const { ImportDeclaration: checkImport } = create({
+      options: [
+        [
+          {
+            module: 'src/components/ui',
+            imported: ['SomeRestrictedModule'],
+            allowReferenceFrom: ['src/pages'],
+          },
+        ],
+      ],
+      getFilename,
+      report,
+    })
+
+    checkImport(mockImportDeclaration)
+
+    expect(getFilename).toBeCalledTimes(1)
+    expect(report.mock.calls).toHaveLength(0)
+    expect(report).not.toBeCalled();
   })
 
   it('should pass relativeFilePath value to resolveImportPath if resolveRelativeImport is true', () => {

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -330,9 +330,9 @@ describe('create.ImportDeclaration', () => {
   })
 
   it('should report if not allowed multiple specifiers from target module', () => {
-    // relativePath: src/components/pages/aaa.ts
+    // relativePath: src/components/button.tsx
     // importPath: src/components/ui/Text
-    // dependency.module: src/components/ui, dependency.importedMembers: ['Text'], dependency.allowReferenceFrom: ['src/components/pages'], allowSameModule: true
+    // dependency.module: src/components/ui, dependency.importedMembers: ['Text', 'TextProps'], dependency.allowReferenceFrom: ['src/pages'], allowSameModule: true
 
     resolveImportPath.mockReturnValue('src/components/ui/Text')
     const getFilename = jest.fn(() =>
@@ -363,7 +363,7 @@ describe('create.ImportDeclaration', () => {
   it('should not report if only allowed specifier from target module', () => {
     // relativePath: src/components/pages/aaa.ts
     // importPath: src/components/ui/Text
-    // dependency.module: src/components/ui, dependency.importedMembers: ['Text'], dependency.allowReferenceFrom: ['src/components/pages'], allowSameModule: true
+    // dependency.module: src/components/ui, dependency.importedMembers: ['SomeRestrictedModule'], dependency.allowReferenceFrom: ['src/pages'], allowSameModule: true
 
     resolveImportPath.mockReturnValue('src/components/ui/Text')
     const getFilename = jest.fn(() =>

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -245,7 +245,7 @@ describe('create.ImportDeclaration', () => {
   it('should report if not allowed specifier from target module', () => {
     // relativePath: src/components/pages/aaa.ts
     // importPath: src/components/ui/Text
-    // dependency.module: src/components/ui, dependency.imported: ['Text'], dependency.allowReferenceFrom: ['src/components/pages'], allowSameModule: true
+    // dependency.module: src/components/ui, dependency.importedMembers: ['Text'], dependency.allowReferenceFrom: ['src/components/pages'], allowSameModule: true
 
     resolveImportPath.mockReturnValue('src/components/ui/Text')
     const getFilename = jest.fn(() =>
@@ -270,7 +270,7 @@ describe('create.ImportDeclaration', () => {
   it('should not report if allowed specifier from target module', () => {
     // relativePath: src/components/pages/aaa.ts
     // importPath: src/components/ui/Text
-    // dependency.module: src/components/ui, dependency.imported: ['Text'], dependency.allowReferenceFrom: ['src/components/pages'], allowSameModule: true
+    // dependency.module: src/components/ui, dependency.importedMembers: ['Text'], dependency.allowReferenceFrom: ['src/components/pages'], allowSameModule: true
 
     resolveImportPath.mockReturnValue('src/components/ui/Text')
     const getFilename = jest.fn(() =>
@@ -282,7 +282,7 @@ describe('create.ImportDeclaration', () => {
         [
           {
             module: 'src/components/ui',
-            imported: ['Text'],
+            importedMembers: ['Text'],
             allowReferenceFrom: ['src/pages'],
           },
         ],
@@ -301,7 +301,7 @@ describe('create.ImportDeclaration', () => {
   it('should report if not allowed specifier from target module', () => {
     // relativePath: src/components/pages/aaa.ts
     // importPath: src/components/ui/Text
-    // dependency.module: src/components/ui, dependency.imported: ['Text'], dependency.allowReferenceFrom: ['src/components/pages'], allowSameModule: true
+    // dependency.module: src/components/ui, dependency.importedMembers: ['Text'], dependency.allowReferenceFrom: ['src/components/pages'], allowSameModule: true
 
     resolveImportPath.mockReturnValue('src/components/ui/Text')
     const getFilename = jest.fn(() =>
@@ -313,7 +313,7 @@ describe('create.ImportDeclaration', () => {
         [
           {
             module: 'src/components/ui',
-            imported: ['Text'],
+            importedMembers: ['Text'],
             allowReferenceFrom: ['src/pages'],
           },
         ],
@@ -332,7 +332,7 @@ describe('create.ImportDeclaration', () => {
   it('should report if not allowed multiple specifiers from target module', () => {
     // relativePath: src/components/pages/aaa.ts
     // importPath: src/components/ui/Text
-    // dependency.module: src/components/ui, dependency.imported: ['Text'], dependency.allowReferenceFrom: ['src/components/pages'], allowSameModule: true
+    // dependency.module: src/components/ui, dependency.importedMembers: ['Text'], dependency.allowReferenceFrom: ['src/components/pages'], allowSameModule: true
 
     resolveImportPath.mockReturnValue('src/components/ui/Text')
     const getFilename = jest.fn(() =>
@@ -344,7 +344,7 @@ describe('create.ImportDeclaration', () => {
         [
           {
             module: 'src/components/ui',
-            imported: ['Text', 'TextProps'],
+            importedMembers: ['Text', 'TextProps'],
             allowReferenceFrom: ['src/pages'],
           },
         ],
@@ -363,7 +363,7 @@ describe('create.ImportDeclaration', () => {
   it('should not report if only allowed specifier from target module', () => {
     // relativePath: src/components/pages/aaa.ts
     // importPath: src/components/ui/Text
-    // dependency.module: src/components/ui, dependency.imported: ['Text'], dependency.allowReferenceFrom: ['src/components/pages'], allowSameModule: true
+    // dependency.module: src/components/ui, dependency.importedMembers: ['Text'], dependency.allowReferenceFrom: ['src/components/pages'], allowSameModule: true
 
     resolveImportPath.mockReturnValue('src/components/ui/Text')
     const getFilename = jest.fn(() =>
@@ -375,7 +375,7 @@ describe('create.ImportDeclaration', () => {
         [
           {
             module: 'src/components/ui',
-            imported: ['SomeRestrictedModule'],
+            importedMembers: ['SomeRestrictedModule'],
             allowReferenceFrom: ['src/pages'],
           },
         ],

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -9,7 +9,33 @@ const mockImportDeclaration = {
   start: 72,
   end: 116,
   specifiers: [
+    // specifiersにはImportDefaultSpecifier/ImportNamespaceSpecifier/ImportSpecifierがあり、実際には同時に動くことはないが念のため3つともテストケースに対して用意する
     {
+      // import * as React from 'react'
+      "type": "ImportNamespaceSpecifier",
+      "start": 52,
+      "end": 62,
+      "local": {
+        "type": "Identifier",
+        "start": 57,
+        "end": 62,
+        "name": "React"
+      }
+    },
+    {
+      // import DefaultExport from '@/components/ui/Text';
+      "type": "ImportDefaultSpecifier",
+      "start": 79,
+      "end": 92,
+      "local": {
+        "type": "Identifier",
+        "start": 79,
+        "end": 92,
+        "name": "DefaultExport"
+      }
+    },
+    {
+      // import { Text, TextProps } from '@/components/ui/Text';
       'type': 'ImportSpecifier',
       'start': 81,
       'end': 85,

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -271,7 +271,7 @@ describe('create.ImportDeclaration', () => {
   it('should report if not allowed specifier from target module', () => {
     // relativePath: src/components/pages/aaa.ts
     // importPath: src/components/ui/Text
-    // dependency.module: src/components/ui, dependency.importedMembers: ['Text'], dependency.allowReferenceFrom: ['src/components/pages'], allowSameModule: true
+    // dependency.module: src/components/ui, dependency.targetMembers: ['Text'], dependency.allowReferenceFrom: ['src/components/pages'], allowSameModule: true
 
     resolveImportPath.mockReturnValue('src/components/ui/Text')
     const getFilename = jest.fn(() =>
@@ -296,7 +296,7 @@ describe('create.ImportDeclaration', () => {
   it('should not report if allowed specifier from target module', () => {
     // relativePath: src/components/pages/aaa.ts
     // importPath: src/components/ui/Text
-    // dependency.module: src/components/ui, dependency.importedMembers: ['Text'], dependency.allowReferenceFrom: ['src/components/pages'], allowSameModule: true
+    // dependency.module: src/components/ui, dependency.targetMembers: ['Text'], dependency.allowReferenceFrom: ['src/components/pages'], allowSameModule: true
 
     resolveImportPath.mockReturnValue('src/components/ui/Text')
     const getFilename = jest.fn(() =>
@@ -308,7 +308,7 @@ describe('create.ImportDeclaration', () => {
         [
           {
             module: 'src/components/ui',
-            importedMembers: ['Text'],
+            targetMembers: ['Text'],
             allowReferenceFrom: ['src/pages'],
           },
         ],
@@ -327,7 +327,7 @@ describe('create.ImportDeclaration', () => {
   it('should report if not allowed specifier from target module', () => {
     // relativePath: src/components/pages/aaa.ts
     // importPath: src/components/ui/Text
-    // dependency.module: src/components/ui, dependency.importedMembers: ['Text'], dependency.allowReferenceFrom: ['src/components/pages'], allowSameModule: true
+    // dependency.module: src/components/ui, dependency.targetMembers: ['Text'], dependency.allowReferenceFrom: ['src/components/pages'], allowSameModule: true
 
     resolveImportPath.mockReturnValue('src/components/ui/Text')
     const getFilename = jest.fn(() =>
@@ -339,7 +339,7 @@ describe('create.ImportDeclaration', () => {
         [
           {
             module: 'src/components/ui',
-            importedMembers: ['Text'],
+            targetMembers: ['Text'],
             allowReferenceFrom: ['src/pages'],
           },
         ],
@@ -358,7 +358,7 @@ describe('create.ImportDeclaration', () => {
   it('should report if not allowed multiple specifiers from target module', () => {
     // relativePath: src/components/button.tsx
     // importPath: src/components/ui/Text
-    // dependency.module: src/components/ui, dependency.importedMembers: ['Text', 'TextProps'], dependency.allowReferenceFrom: ['src/pages'], allowSameModule: true
+    // dependency.module: src/components/ui, dependency.targetMembers: ['Text', 'TextProps'], dependency.allowReferenceFrom: ['src/pages'], allowSameModule: true
 
     resolveImportPath.mockReturnValue('src/components/ui/Text')
     const getFilename = jest.fn(() =>
@@ -370,7 +370,7 @@ describe('create.ImportDeclaration', () => {
         [
           {
             module: 'src/components/ui',
-            importedMembers: ['Text', 'TextProps'],
+            targetMembers: ['Text', 'TextProps'],
             allowReferenceFrom: ['src/pages'],
           },
         ],
@@ -389,7 +389,7 @@ describe('create.ImportDeclaration', () => {
   it('should not report if only allowed specifier from target module', () => {
     // relativePath: src/components/pages/aaa.ts
     // importPath: src/components/ui/Text
-    // dependency.module: src/components/ui, dependency.importedMembers: ['SomeRestrictedModule'], dependency.allowReferenceFrom: ['src/pages'], allowSameModule: true
+    // dependency.module: src/components/ui, dependency.targetMembers: ['SomeRestrictedModule'], dependency.allowReferenceFrom: ['src/pages'], allowSameModule: true
 
     resolveImportPath.mockReturnValue('src/components/ui/Text')
     const getFilename = jest.fn(() =>
@@ -401,7 +401,7 @@ describe('create.ImportDeclaration', () => {
         [
           {
             module: 'src/components/ui',
-            importedMembers: ['SomeRestrictedModule'],
+            targetMembers: ['SomeRestrictedModule'],
             allowReferenceFrom: ['src/pages'],
           },
         ],

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -4,56 +4,54 @@ const resolveImportPath = require('../strict-dependencies/resolveImportPath')
 
 jest.mock('../strict-dependencies/resolveImportPath')
 
-function execCheckImport(checkImport) {
-  checkImport({
-    type: 'ImportDeclaration',
-    start: 72,
-    end: 116,
-    specifiers: [
-      {
-        'type': 'ImportSpecifier',
+const mockImportDeclaration = {
+  type: 'ImportDeclaration',
+  start: 72,
+  end: 116,
+  specifiers: [
+    {
+      'type': 'ImportSpecifier',
+      'start': 81,
+      'end': 85,
+      'imported': {
+        'type': 'Identifier',
         'start': 81,
         'end': 85,
-        'imported': {
-          'type': 'Identifier',
-          'start': 81,
-          'end': 85,
-          'name': 'Text'
-        },
-        'local': {
-          'type': 'Identifier',
-          'start': 81,
-          'end': 85,
-          'name': 'Text'
-        }
+        'name': 'Text'
       },
-      {
-        'type': 'ImportSpecifier',
+      'local': {
+        'type': 'Identifier',
+        'start': 81,
+        'end': 85,
+        'name': 'Text'
+      }
+    },
+    {
+      'type': 'ImportSpecifier',
+      'start': 87,
+      'end': 96,
+      'imported': {
+        'type': 'Identifier',
         'start': 87,
         'end': 96,
-        'imported': {
-          'type': 'Identifier',
-          'start': 87,
-          'end': 96,
-          'name': 'TextProps'
-        },
-        'local': {
-          'type': 'Identifier',
-          'start': 87,
-          'end': 96,
-          'name': 'TextProps'
-        }
+        'name': 'TextProps'
+      },
+      'local': {
+        'type': 'Identifier',
+        'start': 87,
+        'end': 96,
+        'name': 'TextProps'
       }
-    ],
-    source: {
-      type: 'Literal',
-      start: 93,
-      end: 115,
-      value: '@/components/ui/Text',
-      raw: '"@/components/ui/Text"',
-    },
-  })
-}
+    }
+  ],
+  source: {
+    type: 'Literal',
+    start: 93,
+    end: 115,
+    value: '@/components/ui/Text',
+    raw: '"@/components/ui/Text"',
+  },
+};
 
 describe('create', () => {
   it('should return object', () => {
@@ -74,7 +72,7 @@ describe('create.ImportDeclaration', () => {
       report,
     })
 
-    execCheckImport(checkImport)
+    checkImport(mockImportDeclaration)
 
     expect(getFilename).toBeCalledTimes(1)
     expect(report).not.toBeCalled()
@@ -95,7 +93,7 @@ describe('create.ImportDeclaration', () => {
       report,
     })
 
-    execCheckImport(checkImport)
+    checkImport(mockImportDeclaration)
 
     expect(getFilename).toBeCalledTimes(1)
     expect(report).not.toBeCalled()
@@ -117,7 +115,7 @@ describe('create.ImportDeclaration', () => {
       report,
     })
 
-    execCheckImport(checkImport)
+    checkImport(mockImportDeclaration)
 
     expect(getFilename).toBeCalledTimes(1)
     expect(report).not.toBeCalled()
@@ -139,7 +137,7 @@ describe('create.ImportDeclaration', () => {
       report,
     })
 
-    execCheckImport(checkImport)
+    checkImport(mockImportDeclaration)
 
     expect(getFilename).toBeCalledTimes(1)
     expect(report).not.toBeCalled()
@@ -161,7 +159,7 @@ describe('create.ImportDeclaration', () => {
       report,
     })
 
-    execCheckImport(checkImport)
+    checkImport(mockImportDeclaration)
 
     expect(getFilename).toBeCalledTimes(1)
     expect(report.mock.calls).toHaveLength(1)
@@ -184,7 +182,7 @@ describe('create.ImportDeclaration', () => {
       report,
     })
 
-    execCheckImport(checkImport)
+    checkImport(mockImportDeclaration)
 
     expect(getFilename).toBeCalledTimes(1)
     expect(report.mock.calls).toHaveLength(1)
@@ -207,7 +205,7 @@ describe('create.ImportDeclaration', () => {
       report,
     })
 
-    execCheckImport(checkImport)
+    checkImport(mockImportDeclaration)
 
     expect(getFilename).toBeCalledTimes(1)
     expect(report).not.toBeCalled()
@@ -237,13 +235,11 @@ describe('create.ImportDeclaration', () => {
       report,
     })
 
-    execCheckImport(checkImport)
+    checkImport(mockImportDeclaration)
 
     expect(getFilename).toBeCalledTimes(1)
     expect(report.mock.calls).toHaveLength(1)
-    expect(report.mock.calls[0][1]).toBe(
-      'import 'src/components/ui/Text' is not allowed from src/components/ui/aaa.ts.'
-    )
+    expect(report.mock.calls[0][1]).toBe('import \'src/components/ui/Text\' is not allowed from src/components/ui/aaa.ts.')
   })
 
   it('should report if not allowed specifier from target module', () => {
@@ -264,11 +260,11 @@ describe('create.ImportDeclaration', () => {
       report,
     })
 
-    execCheckImport(checkImport)
+    checkImport(mockImportDeclaration)
 
     expect(getFilename).toBeCalledTimes(1)
     expect(report.mock.calls).toHaveLength(1)
-    expect(report.mock.calls[0][1]).toBe('import \'src/components/ui/Text\' is not allowed from src/components/ui/aaa.ts.')
+    expect(report.mock.calls[0][1]).toBe('import \'src/components/ui/Text\' is not allowed from src/pages/index.tsx.')
   })
 
   it('should not report if allowed specifier from target module', () => {
@@ -295,11 +291,42 @@ describe('create.ImportDeclaration', () => {
       report,
     })
 
-    execCheckImport(checkImport)
+    checkImport(mockImportDeclaration)
+
+    expect(getFilename).toBeCalledTimes(1)
+    expect(report.mock.calls).toHaveLength(0)
+    expect(report).not.toBeCalled()
+  })
+
+  it('should report if allowed specifier from target module', () => {
+    // relativePath: src/components/pages/aaa.ts
+    // importPath: src/components/ui/Text
+    // dependency.module: src/components/ui, dependency.imported: ['Text'], dependency.allowReferenceFrom: ['src/components/pages'], allowSameModule: true
+
+    resolveImportPath.mockReturnValue('src/components/ui/Text')
+    const getFilename = jest.fn(() =>
+      path.join(process.cwd(), 'src/components/button.tsx')
+    )
+    const report = jest.fn()
+    const { ImportDeclaration: checkImport } = create({
+      options: [
+        [
+          {
+            module: 'src/components/ui',
+            imported: ['Text'],
+            allowReferenceFrom: ['src/pages'],
+          },
+        ],
+      ],
+      getFilename,
+      report,
+    })
+
+    checkImport(mockImportDeclaration)
 
     expect(getFilename).toBeCalledTimes(1)
     expect(report.mock.calls).toHaveLength(1)
-    expect(report).not.toBeCalled()
+    expect(report.mock.calls[0][1]).toBe('import specifier \'Text\' is not allowed from src/components/button.tsx.')
   })
 
   it('should pass relativeFilePath value to resolveImportPath if resolveRelativeImport is true', () => {
@@ -315,7 +342,7 @@ describe('create.ImportDeclaration', () => {
       report,
     })
 
-    execCheckImport(checkImport)
+    checkImport(mockImportDeclaration)
 
     expect(resolveImportPath).toBeCalledWith('@/components/ui/Text', 'src/components/ui/aaa.ts', {})
     expect(getFilename).toBeCalledTimes(1)
@@ -334,7 +361,7 @@ describe('create.ImportDeclaration', () => {
       report,
     })
 
-    execCheckImport(checkImport)
+    checkImport(mockImportDeclaration)
 
     expect(resolveImportPath).toBeCalledWith('@/components/ui/Text', null, {})
     expect(getFilename).toBeCalledTimes(1)

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -329,6 +329,37 @@ describe('create.ImportDeclaration', () => {
     expect(report.mock.calls[0][1]).toBe('import specifier \'Text\' is not allowed from src/components/button.tsx.')
   })
 
+  it('should report if not allowed multiple specifiers from target module', () => {
+    // relativePath: src/components/pages/aaa.ts
+    // importPath: src/components/ui/Text
+    // dependency.module: src/components/ui, dependency.imported: ['Text'], dependency.allowReferenceFrom: ['src/components/pages'], allowSameModule: true
+
+    resolveImportPath.mockReturnValue('src/components/ui/Text')
+    const getFilename = jest.fn(() =>
+      path.join(process.cwd(), 'src/components/button.tsx')
+    )
+    const report = jest.fn()
+    const { ImportDeclaration: checkImport } = create({
+      options: [
+        [
+          {
+            module: 'src/components/ui',
+            imported: ['Text', 'TextProps'],
+            allowReferenceFrom: ['src/pages'],
+          },
+        ],
+      ],
+      getFilename,
+      report,
+    })
+
+    checkImport(mockImportDeclaration)
+
+    expect(getFilename).toBeCalledTimes(1)
+    expect(report.mock.calls).toHaveLength(1)
+    expect(report.mock.calls[0][1]).toBe('import specifier \'Text, TextProps\' is not allowed from src/components/button.tsx.')
+  })
+
   it('should not report if only allowed specifier from target module', () => {
     // relativePath: src/components/pages/aaa.ts
     // importPath: src/components/ui/Text

--- a/strict-dependencies/index.js
+++ b/strict-dependencies/index.js
@@ -76,8 +76,8 @@ module.exports = {
 
           /**
            * 1. 参照元チェックをしてAllowであればそこで処理を終了する
-           * 2. importedが指定されていれば、importedと実際にimportしているモジュールを比較して含まれていればエラーレポートして処理を終了する
-           * 3. importedが指定されていない場合は、エラー扱いなのでエラーレポートして処理を終了する
+           * 2. importedMembersが指定されていれば、importedMembersと実際にimportしているモジュールを比較して含まれていればエラーレポートして処理を終了する
+           * 3. importedMembersが指定されていない場合は、エラー扱いなのでエラーレポートして処理を終了する
            */
 
           const isAllowedByPath =
@@ -93,8 +93,8 @@ module.exports = {
           function getCommonElements(arrA, arrB) {
             return arrA.filter(element => arrB.includes(element));
           }
-          if (dependency.imported && Array.isArray(dependency.imported)) {
-            const commonImportedList = getCommonElements(dependency.imported, importedModules)
+          if (dependency.importedMembers && Array.isArray(dependency.importedMembers)) {
+            const commonImportedList = getCommonElements(dependency.importedMembers, importedModules)
             if (commonImportedList.length > 0) {
               context.report(node, `import specifier '${commonImportedList.join(', ')}' is not allowed from ${relativeFilePath}.`)
             }

--- a/strict-dependencies/index.js
+++ b/strict-dependencies/index.js
@@ -96,7 +96,7 @@ module.exports = {
           if (dependency.imported && Array.isArray(dependency.imported)) {
             const commonImportedList = getCommonElements(dependency.imported, importedModules)
             if (commonImportedList.length > 0) {
-              context.report(node, `import specifier '${commonImportedList.join(',')}' is not allowed from ${relativeFilePath}.`)
+              context.report(node, `import specifier '${commonImportedList.join(', ')}' is not allowed from ${relativeFilePath}.`)
             }
             return;
           }

--- a/strict-dependencies/index.js
+++ b/strict-dependencies/index.js
@@ -78,8 +78,8 @@ module.exports = {
 
           /**
            * 1. 参照元チェックをしてAllowであればそこで処理を終了する
-           * 2. importedMembersが指定されていれば、importedMembersと実際にimportしているモジュールを比較して含まれていればエラーレポートして処理を終了する
-           * 3. importedMembersが指定されていない場合は、エラー扱いなのでエラーレポートして処理を終了する
+           * 2. targetMembersが指定されていれば、targetMembersと実際にimportしているモジュールを比較して含まれていればエラーレポートして処理を終了する
+           * 3. targetMembersが指定されていない場合は、エラー扱いなのでエラーレポートして処理を終了する
            */
 
           const isAllowedByPath =
@@ -95,8 +95,8 @@ module.exports = {
           function getCommonElements(arrA, arrB) {
             return arrA.filter(element => arrB.includes(element));
           }
-          if (dependency.importedMembers && Array.isArray(dependency.importedMembers)) {
-            const commonImportedList = getCommonElements(dependency.importedMembers, importedModules)
+          if (dependency.targetMembers && Array.isArray(dependency.targetMembers)) {
+            const commonImportedList = getCommonElements(dependency.targetMembers, importedModules)
             if (commonImportedList.length > 0) {
               context.report(node, `import specifier '${commonImportedList.join(', ')}' is not allowed from ${relativeFilePath}.`)
             }

--- a/strict-dependencies/index.js
+++ b/strict-dependencies/index.js
@@ -67,7 +67,9 @@ module.exports = {
       const fileFullPath = context.getFilename()
       const relativeFilePath = normalize(path.relative(process.cwd(), fileFullPath))
       const importPath = resolveImportPath(node.source.value, resolveRelativeImport ? relativeFilePath : null, pathIndexMap)
-      const importedModules = node.specifiers.map(spec => spec.imported.name)
+
+      // specにはImportDefaultSpecifier/ImportNamespaceSpecifier/ImportSpecifierがあり、ImportSpecifierの場合はimportedが存在する
+      const importedModules = node.specifiers.filter(spec => 'imported' in spec).map(spec => spec.imported.name)
 
       dependencies
         .forEach((dependency) => {


### PR DESCRIPTION
## 概要
新しいオプションの提案をさせていただきます。ひとまず実現可能か検証するために、プラグイン実装+テストコード実装まで進めてみたので、Issueの起票ではなく最初からPull Requestの起票という形で進めました。問題あればIssue作成しますのでお伝えください。

## オプション概要
`importedMembers`というオプションを追加します。
これは、たとえばreactのSuspenseはsrc/libs以下からしか参照したくない、という場合に以下のように指定できることを目標としています。

```
          {
            module: 'react',
            importedMembers: ['Suspense'],
            allowReferenceFrom: ['src/libs'],
          },
```

こうすると、以下のような挙動を実現します。
- src/libs以外からimport {Suspense, useEffect} from 'react'するとerror reportされます。
- src/libs以外でimport {useState, useEffect} from 'react'するとerror reportされません。
- src/libsでimport {Suspense, useEffect} from 'react'するとerror reportされません。
- src/libsでimport {useState, useEffect} from 'react'するとerror reportされません。

背景として、
本プラグインは`next/router`からのimportをさせないなど、あくまでfrom以降のModule名で縛ることを目的としていますが、必ずしもDependenciesを制限したい対象がModule名とは限らず、上記例のように'react'の中のSuspenseに限って利用範囲を制限したい、というユースケースに対応できていないように見えました。もし既存で対応されていれば教えていただきたいです。

## 詳細
node.specifiersを見ればimport対象を取得できるのでそれでレポートできるように実装し、テストコードによって動作確認としています。プラグイン本体とテストコードは必要最低限だけ組んでいるため、本オプションが本実装して良さそうであればもう少し精査します。
オプションの内容が妥当そうであれば、READMEの記入なども行おうと思っています。

## 特にご確認をお願いしたいこと
- 本オプションの追加は本プラグインの提供したい価値に合致しているか※エッジケースではあると思うので、サポートしないという判断もあるかと思っています
- 本オプションは一般的に必要だと思うか
- オプションのKey名はimportedMembersが妥当か（他の候補：specifiers, identifiers, imported, targetなど）

