### PR TITLE
Added new option 'allowTypeImport'

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ npm install eslint-plugin-strict-dependencies --save-dev
     - Paths of files where target module imports are allowed.
   - allowSameModule: `boolean`
     - Whether it can be imported by other files in the same directory
-  - allowTypeImport: `boolean`
-    - Whether to allow type imports
+  - excludeTypeImportChecks: `boolean`
+    - Whether to exclude type import checks
     - e.x. `import type { Suspense } from 'react'`
 
 ### Options
@@ -79,8 +79,8 @@ npm install eslint-plugin-strict-dependencies --save-dev
         "allowReferenceFrom": ["src/components/page"],
         // components/ui can import other components/ui
         "allowSameModule": true,
-        // components/ui allow type import
-        "allowTypeImport": true
+        // components/ui exclude type import checks
+        "excludeTypeImportChecks": true
       },
 
       /**

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ npm install eslint-plugin-strict-dependencies --save-dev
     - Paths of files where target module imports are allowed.
   - allowSameModule: `boolean`
     - Whether it can be imported by other files in the same directory
+  - allowTypeImport: `boolean`
+    - Whether to allow type imports
+    - e.x. `import type { Suspense } from 'react'`
 
 ### Options
 
@@ -75,7 +78,9 @@ npm install eslint-plugin-strict-dependencies --save-dev
         "module": "src/components/ui",
         "allowReferenceFrom": ["src/components/page"],
         // components/ui can import other components/ui
-        "allowSameModule": true
+        "allowSameModule": true,
+        // components/ui allow type import
+        "allowTypeImport": true
       },
 
       /**

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -464,7 +464,7 @@ describe('create.ImportDeclaration', () => {
   it('should not report if allowTypeImport is true', () => {
     resolveImportPath.mockReturnValue('src/components/ui/Text')
     const getFilename = jest.fn(() =>
-      path.join(process.cwd(), 'src/components/ui/aaa.ts')
+      path.join(process.cwd(), 'src/pages/index.tsx')
     )
     const report = jest.fn()
     const { ImportDeclaration: checkImport } = create({

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -79,6 +79,11 @@ const mockImportDeclaration = {
   },
 };
 
+const mockImportDeclarationImportKindType = {
+  importKind: 'type',
+  ...mockImportDeclaration
+};
+
 describe('create', () => {
   it('should return object', () => {
     const created = create({options: [[]]})
@@ -452,6 +457,33 @@ describe('create.ImportDeclaration', () => {
     checkImport(mockImportDeclaration)
 
     expect(resolveImportPath).toBeCalledWith('@/components/ui/Text', null, {})
+    expect(getFilename).toBeCalledTimes(1)
+    expect(report).not.toBeCalled()
+  })
+
+  it('should not report if allowTypeImport is true', () => {
+    resolveImportPath.mockReturnValue('src/components/ui/Text')
+    const getFilename = jest.fn(() =>
+      path.join(process.cwd(), 'src/components/ui/aaa.ts')
+    )
+    const report = jest.fn()
+    const { ImportDeclaration: checkImport } = create({
+      options: [
+        [
+          {
+            module: 'src/components/ui',
+            allowReferenceFrom: ['src/aaa'],
+            allowSameModule: false,
+            allowTypeImport: true,
+          },
+        ],
+      ],
+      getFilename,
+      report,
+    })
+
+    checkImport(mockImportDeclarationImportKindType)
+
     expect(getFilename).toBeCalledTimes(1)
     expect(report).not.toBeCalled()
   })

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -461,7 +461,7 @@ describe('create.ImportDeclaration', () => {
     expect(report).not.toBeCalled()
   })
 
-  it('should not report if allowTypeImport is true', () => {
+  it('should not report if excludeTypeImportChecks is true', () => {
     resolveImportPath.mockReturnValue('src/components/ui/Text')
     const getFilename = jest.fn(() =>
       path.join(process.cwd(), 'src/pages/index.tsx')
@@ -474,7 +474,7 @@ describe('create.ImportDeclaration', () => {
             module: 'src/components/ui',
             allowReferenceFrom: ['src/aaa'],
             allowSameModule: false,
-            allowTypeImport: true,
+            excludeTypeImportChecks: true,
           },
         ],
       ],

--- a/strict-dependencies/index.js
+++ b/strict-dependencies/index.js
@@ -40,6 +40,9 @@ module.exports = {
               allowSameModule: {
                 type: 'boolean',
               },
+              allowTypeImport: {
+                type: 'boolean'
+              }
             },
           },
         ],
@@ -87,7 +90,8 @@ module.exports = {
           dependency.allowReferenceFrom.some((allowPath) =>
             isMatch(relativeFilePath, allowPath),
           ) || // または同一モジュール間の参照が許可されている場合
-          (dependency.allowSameModule && isMatch(relativeFilePath, dependency.module))
+          (dependency.allowSameModule && isMatch(relativeFilePath, dependency.module)) ||
+            dependency.allowTypeImport && node.importKind === 'type'
 
           if (isAllowedByPath) return
 

--- a/strict-dependencies/index.js
+++ b/strict-dependencies/index.js
@@ -90,8 +90,9 @@ module.exports = {
           dependency.allowReferenceFrom.some((allowPath) =>
             isMatch(relativeFilePath, allowPath),
           ) || // または同一モジュール間の参照が許可されている場合
-          (dependency.allowSameModule && isMatch(relativeFilePath, dependency.module)) ||
-            dependency.allowTypeImport && node.importKind === 'type'
+          (dependency.allowSameModule && isMatch(relativeFilePath, dependency.module))
+          // または明示的に対象外としたtype importである場合
+          || (dependency.allowTypeImport && node.importKind === 'type')
 
           if (isAllowedByPath) return
 

--- a/strict-dependencies/index.js
+++ b/strict-dependencies/index.js
@@ -40,7 +40,7 @@ module.exports = {
               allowSameModule: {
                 type: 'boolean',
               },
-              allowTypeImport: {
+              excludeTypeImportChecks: {
                 type: 'boolean'
               }
             },
@@ -92,7 +92,7 @@ module.exports = {
           ) || // または同一モジュール間の参照が許可されている場合
           (dependency.allowSameModule && isMatch(relativeFilePath, dependency.module))
           // または明示的に対象外としたtype importである場合
-          || (dependency.allowTypeImport && node.importKind === 'type')
+          || (dependency.excludeTypeImportChecks && node.importKind === 'type')
 
           if (isAllowedByPath) return
 


### PR DESCRIPTION
In this PR, I have added a new option 'allowTypeImport'.

This option allows the import of types. 
Specifically, it allows imports in the form of `import type { Suspense } from 'react`.


This option was necessary to meet the need in our project to limit the import of class entities from specific directories only, while allowing types to be referenced from anywhere.

Testing was done in `__tests__/index.js` and confirmed to work without any issues.

Also, this new option 'allowTypeImport' is false by default, so it should not affect existing code or functionality.


Thank you for your review.