### PR TITLE
Add tsconfigPath option to customize TypeScript config file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ npm install eslint-plugin-strict-dependencies --save-dev
     ```typescript
     import bbb from './bbb';
     ```
-     - `resolveRelativeImport = false`: Resolve as `./bbb` (excluded from lint target)
-     - `resolveRelativeImport = true`:  Resolve as `src/components/bbb`: (included from lint target)
+    - `resolveRelativeImport = false`: Resolve as `./bbb` (excluded from lint target)
+    - `resolveRelativeImport = true`: Resolve as `src/components/bbb`: (included from lint target)
 
 - pathIndexMap: `object[default = null]`
   - In eslint-plugin-strict-dependencies, path alias resolution is performed based on the paths specified in the tsconfig.
@@ -45,11 +45,16 @@ npm install eslint-plugin-strict-dependencies --save-dev
       ```json
       {
         "compilerOptions": {
-            "*": ["aaa/*", "bbb/*"]
+          "*": ["aaa/*", "bbb/*"]
           },
       }
       ```
     - `pathIndexMap = { "*": 1 } `: `"bbb/*"` is used.
+
+- tsconfigPath: `string[default = "tsconfig.json"]`
+  - Path to the TypeScript configuration file.
+  - By default, `tsconfig.json` is used, but you can specify a custom file name.
+  - e.x. `"tsconfig.app.json"` or `"tsconfig.base.json"`
 
 ## Usage
 
@@ -106,8 +111,9 @@ npm install eslint-plugin-strict-dependencies --save-dev
     ],
     // options
     // {
-    //   "resolveRelativeImport": true
-    //   "pathIndexMap": { "*": 1 }
+    //   "resolveRelativeImport": true,
+    //   "pathIndexMap": { "*": 1 },
+    //   "tsconfigPath": "tsconfig.app.json"
     // }
   ]
 }

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -437,7 +437,7 @@ describe('create.ImportDeclaration', () => {
 
     checkImport(mockImportDeclaration)
 
-    expect(resolveImportPath).toBeCalledWith('@/components/ui/Text', 'src/components/ui/aaa.ts', {})
+    expect(resolveImportPath).toBeCalledWith('@/components/ui/Text', 'src/components/ui/aaa.ts', {}, undefined)
     expect(getFilename).toBeCalledTimes(1)
     expect(report).not.toBeCalled()
   })
@@ -456,7 +456,7 @@ describe('create.ImportDeclaration', () => {
 
     checkImport(mockImportDeclaration)
 
-    expect(resolveImportPath).toBeCalledWith('@/components/ui/Text', null, {})
+    expect(resolveImportPath).toBeCalledWith('@/components/ui/Text', null, {}, undefined)
     expect(getFilename).toBeCalledTimes(1)
     expect(report).not.toBeCalled()
   })

--- a/__tests__/resolveImportPath.js
+++ b/__tests__/resolveImportPath.js
@@ -1,5 +1,6 @@
 const resolveImportPath = require('../strict-dependencies/resolveImportPath')
-const {readFileSync} = require('fs')
+const { readFileSync } = require('fs')
+const path = require('path')
 
 jest.mock('fs')
 
@@ -9,7 +10,14 @@ describe('resolveImportPath', () => {
     // import Text from '../../components/ui/Text'
 
     readFileSync.mockReturnValue(JSON.stringify({}))
-    expect(resolveImportPath('../../components/ui/Text', 'src/pages/aaa/bbb.ts', {})).toBe('src/components/ui/Text')
+    expect(
+      resolveImportPath(
+        '../../components/ui/Text',
+        'src/pages/aaa/bbb.ts',
+        {},
+        undefined
+      )
+    ).toBe('src/components/ui/Text')
   })
 
   it('should not resolve relative path if relativeFilePath is empty', () => {
@@ -17,44 +25,56 @@ describe('resolveImportPath', () => {
     // import Text from '../../components/ui/Text'
 
     readFileSync.mockReturnValue(JSON.stringify({}))
-    expect(resolveImportPath('../../components/ui/Text', null, {})).toBe('../../components/ui/Text')
+    expect(
+      resolveImportPath('../../components/ui/Text', null, {}, undefined)
+    ).toBe('../../components/ui/Text')
   })
 
   it('should do nothing if tsconfig.json does not exist', () => {
     readFileSync.mockImplementation(() => {
       throw new Error()
     })
-    expect(resolveImportPath('components/aaa/bbb', null, {})).toBe('components/aaa/bbb')
+    expect(resolveImportPath('components/aaa/bbb', null, {}, undefined)).toBe(
+      'components/aaa/bbb'
+    )
   })
 
   it('should do nothing if no paths setting', () => {
     readFileSync.mockReturnValue(JSON.stringify({}))
-    expect(resolveImportPath('components/aaa/bbb', null, {})).toBe('components/aaa/bbb')
+    expect(resolveImportPath('components/aaa/bbb', null, {}, undefined)).toBe(
+      'components/aaa/bbb'
+    )
   })
 
   describe('should resolve tsconfig paths', () => {
-    [
+    ;[
       ['@/components/', 'components/', 'components/aaa/bbb'],
       ['@/components', 'components', 'components/aaa/bbb'],
       ['@/components/*', 'components/*', 'components/aaa/bbb'],
     ].forEach(([target, resolve, expected]) => {
       it(`${target}: [${resolve}]`, () => {
-        readFileSync.mockReturnValue(JSON.stringify({
-          compilerOptions: {
-            paths: {
-              [target]: [resolve],
+        readFileSync.mockReturnValue(
+          JSON.stringify({
+            compilerOptions: {
+              paths: {
+                [target]: [resolve],
+              },
             },
-          },
-        }))
+          })
+        )
 
-        expect(resolveImportPath('components/aaa/bbb', null, {})).toBe('components/aaa/bbb')
-        expect(resolveImportPath('@/components/aaa/bbb', null, {})).toBe(expected)
+        expect(
+          resolveImportPath('components/aaa/bbb', null, {}, undefined)
+        ).toBe('components/aaa/bbb')
+        expect(
+          resolveImportPath('@/components/aaa/bbb', null, {}, undefined)
+        ).toBe(expected)
       })
     })
   })
 
   describe('should resolve tsconfig paths with baseUrl', () => {
-    [
+    ;[
       ['.', 'components/aaa/bbb'],
       ['./', 'components/aaa/bbb'],
       ['../', '../components/aaa/bbb'],
@@ -64,17 +84,23 @@ describe('resolveImportPath', () => {
       ['./src/', 'src/components/aaa/bbb'],
     ].forEach(([baseUrl, expected]) => {
       it(baseUrl, () => {
-        readFileSync.mockReturnValue(JSON.stringify({
-          compilerOptions: {
-            baseUrl,
-            paths: {
-              '@/components/': ['components/'],
+        readFileSync.mockReturnValue(
+          JSON.stringify({
+            compilerOptions: {
+              baseUrl,
+              paths: {
+                '@/components/': ['components/'],
+              },
             },
-          },
-        }))
+          })
+        )
 
-        expect(resolveImportPath('components/aaa/bbb', null, {})).toBe('components/aaa/bbb')
-        expect(resolveImportPath('@/components/aaa/bbb', null, {})).toBe(expected)
+        expect(
+          resolveImportPath('components/aaa/bbb', null, {}, undefined)
+        ).toBe('components/aaa/bbb')
+        expect(
+          resolveImportPath('@/components/aaa/bbb', null, {}, undefined)
+        ).toBe(expected)
       })
     })
   })
@@ -86,21 +112,153 @@ describe('resolveImportPath', () => {
           '@/components/*': ['src/components/*', 'src/alternativeComponents/*'],
         },
       },
-    });
+    })
 
     it('should resolve path alias with specified index in pathIndexMap', () => {
-      readFileSync.mockReturnValue(tsConfigWithMultiplePaths);
-      expect(resolveImportPath('@/components/aaa/bbb', null, { '@/components/*': 1 })).toBe('src/alternativeComponents/aaa/bbb');
-    });
-  
+      readFileSync.mockReturnValue(tsConfigWithMultiplePaths)
+      expect(
+        resolveImportPath(
+          '@/components/aaa/bbb',
+          null,
+          { '@/components/*': 1 },
+          undefined
+        )
+      ).toBe('src/alternativeComponents/aaa/bbb')
+    })
+
     it('should resolve path alias with default index:0 if specified index does not exist', () => {
-      readFileSync.mockReturnValue(tsConfigWithMultiplePaths);
-      expect(resolveImportPath('@/components/aaa/bbb', null, { '@/components/*': 5 })).toBe('src/components/aaa/bbb');
-    });
-  
+      readFileSync.mockReturnValue(tsConfigWithMultiplePaths)
+      expect(
+        resolveImportPath(
+          '@/components/aaa/bbb',
+          null,
+          { '@/components/*': 5 },
+          undefined
+        )
+      ).toBe('src/components/aaa/bbb')
+    })
+
     it('should resolve path alias with default index:0 if pathIndexMap is an empty object', () => {
-      readFileSync.mockReturnValue(tsConfigWithMultiplePaths);
-      expect(resolveImportPath('@/components/aaa/bbb', null, {})).toBe('src/components/aaa/bbb');
-    });
+      readFileSync.mockReturnValue(tsConfigWithMultiplePaths)
+      expect(
+        resolveImportPath('@/components/aaa/bbb', null, {}, undefined)
+      ).toBe('src/components/aaa/bbb')
+    })
+  })
+
+  describe('resolveImportPath with tsconfigPath parameter', () => {
+    beforeEach(() => {
+      readFileSync.mockClear()
+    })
+
+    it('should use custom tsconfigPath when specified', () => {
+      const customTsConfig = JSON.stringify({
+        compilerOptions: {
+          paths: {
+            '@/libs/*': ['src/libs/*'],
+          },
+        },
+      })
+      readFileSync.mockImplementation((filePath) => {
+        if (filePath.endsWith('tsconfig.app.json')) {
+          return customTsConfig
+        }
+        return JSON.stringify({})
+      })
+
+      const result = resolveImportPath(
+        '@/libs/utils',
+        null,
+        {},
+        'tsconfig.app.json'
+      )
+      expect(result).toBe('src/libs/utils')
+    })
+
+    it('should use default tsconfig.json when tsconfigPath is not provided', () => {
+      const defaultTsConfig = JSON.stringify({
+        compilerOptions: {
+          paths: {
+            '@/shared/*': ['src/shared/*'],
+          },
+        },
+      })
+      readFileSync.mockImplementation((filePath) => {
+        if (filePath.endsWith('tsconfig.json')) {
+          return defaultTsConfig
+        }
+        return JSON.stringify({})
+      })
+
+      const result = resolveImportPath('@/shared/constants', null, {})
+      expect(result).toBe('src/shared/constants')
+    })
+
+    it('should handle custom tsconfigPath with different file name', () => {
+      const baseTsConfig = JSON.stringify({
+        compilerOptions: {
+          baseUrl: 'src',
+          paths: {
+            '@/components/*': ['components/*'],
+          },
+        },
+      })
+      readFileSync.mockImplementation((filePath) => {
+        if (filePath.endsWith('tsconfig.base.json')) {
+          return baseTsConfig
+        }
+        return JSON.stringify({})
+      })
+
+      const result = resolveImportPath(
+        '@/components/Button',
+        null,
+        {},
+        'tsconfig.base.json'
+      )
+      expect(result).toBe('src/components/Button')
+    })
+
+    it('should handle different tsconfig files with different paths', () => {
+      const appTsConfig = JSON.stringify({
+        compilerOptions: {
+          paths: {
+            '@/app/*': ['src/app/*'],
+          },
+        },
+      })
+      const baseTsConfig = JSON.stringify({
+        compilerOptions: {
+          paths: {
+            '@/base/*': ['src/base/*'],
+          },
+        },
+      })
+      readFileSync.mockImplementation((filePath) => {
+        if (filePath.endsWith('tsconfig.app.json')) {
+          return appTsConfig
+        }
+        if (filePath.endsWith('tsconfig.base.json')) {
+          return baseTsConfig
+        }
+        return JSON.stringify({})
+      })
+
+      const appResult = resolveImportPath(
+        '@/app/main',
+        null,
+        {},
+        'tsconfig.app.json'
+      )
+      expect(appResult).toBe('src/app/main')
+
+      const baseResult = resolveImportPath(
+        '@/base/core',
+        null,
+        {},
+        'tsconfig.base.json'
+      )
+      expect(baseResult).toBe('src/base/core')
+    })
   })
 })

--- a/strict-dependencies/index.js
+++ b/strict-dependencies/index.js
@@ -55,7 +55,10 @@ module.exports = {
           },
           pathIndexMap: {
             type: 'object'
-          }
+          },
+          tsconfigPath: {
+            type: 'string',
+          },
         },
       },
     ],
@@ -65,11 +68,17 @@ module.exports = {
     const options = context.options.length > 1 ? context.options[1] : {}
     const resolveRelativeImport = options.resolveRelativeImport
     const pathIndexMap = options.pathIndexMap ? options.pathIndexMap : {}
+    const tsconfigPath = options.tsconfigPath
 
     function checkImport(node) {
       const fileFullPath = context.getFilename()
       const relativeFilePath = normalize(path.relative(process.cwd(), fileFullPath))
-      const importPath = resolveImportPath(node.source.value, resolveRelativeImport ? relativeFilePath : null, pathIndexMap)
+      const importPath = resolveImportPath(
+        node.source.value,
+        resolveRelativeImport ? relativeFilePath : null,
+        pathIndexMap,
+        tsconfigPath
+      )
 
       // specにはImportDefaultSpecifier/ImportNamespaceSpecifier/ImportSpecifierがあり、ImportSpecifierの場合はimportedが存在する
       const importedModules = node.specifiers.filter(spec => 'imported' in spec).map(spec => spec.imported.name)

--- a/strict-dependencies/resolveImportPath.js
+++ b/strict-dependencies/resolveImportPath.js
@@ -7,14 +7,15 @@ const normalize = require('normalize-path')
 /**
  * import文のrootからのパスを求める
  */
-module.exports = (importPath, relativeFilePath, pathIndexMap) => {
+module.exports = (importPath, relativeFilePath, pathIndexMap, tsconfigPath) => {
   // { [importAlias: string]: OriginalPath }
   const importAliasMap = {}
 
   // Load tsconfig option
   // MEMO: tscとか使って簡単に読める方法がありそう
   try {
-    const tsConfigFilePath = path.join(process.cwd(), '/tsconfig.json')
+    const tsConfigFileName = tsconfigPath || 'tsconfig.json'
+    const tsConfigFilePath = path.join(process.cwd(), tsConfigFileName)
     // Exists ts config
     const tsConfig = parseJSON(tsConfigFilePath)
     if (tsConfig.compilerOptions && tsConfig.compilerOptions.paths) {
@@ -35,7 +36,7 @@ module.exports = (importPath, relativeFilePath, pathIndexMap) => {
   }
 
   const absolutePath = Object.keys(importAliasMap).reduce((resolvedImportPath, key) => {
-    // FIXME: use glob module instead of replace('*')
+      // FIXME: use glob module instead of replace('*')
     return resolvedImportPath.replace(key.replace('*', ''), importAliasMap[key].replace('*', ''))
   }, importPath)
 


### PR DESCRIPTION
Thank you for maintaining this useful plugin! I use it regularly and it's been very helpful for managing module dependencies in my projects.

## Summary

Added `tsconfigPath` option to allow customization of the TypeScript configuration file path.

## Background & Motivation

Currently, this plugin hardcodes reading from `tsconfig.json`. However, in real-world projects, there are cases where multiple `tsconfig.json` files are used (e.g., `tsconfig.json`, `tsconfig.app.json`, `tsconfig.test.json`). The current implementation always reads from `tsconfig.json`, which prevents loading application-specific configurations.

In particular, recent Vite templates create `tsconfig.app.json` by default alongside `tsconfig.json` and `tsconfig.node.json` to separate application-specific settings from the base configuration. This separation allows different TypeScript settings for different parts of the project (client-side application vs. Node.js build tools), improving maintainability and flexibility.

To solve this problem, we added the `tsconfigPath` option to allow users to flexibly specify which TypeScript configuration file to use.

## Changes

### New Feature
- Added `tsconfigPath` option
  - Default: `tsconfig.json` (maintains existing behavior)
  - Can specify custom file names (e.g., `tsconfig.app.json`, `tsconfig.base.json`)

### Modified Files
- `strict-dependencies/index.js`: Added `tsconfigPath` option to schema
- `strict-dependencies/resolveImportPath.js`: Modified to accept `tsconfigPath` parameter and read the specified file
- `__tests__/resolveImportPath.js`: Added test cases for `tsconfigPath` option
- `__tests__/index.js`: Updated `resolveImportPath` calls to support the 4th parameter
- `README.md`: Added documentation for `tsconfigPath` option

## Usage Example

```javascript
// .eslintrc.js
{
  "rules": {
    "strict-dependencies/strict-dependencies": [
      "error",
      [
        {
          "module": "src/components/ui",
          "allowReferenceFrom": ["src/pages"]
        }
      ],
      {
        "tsconfigPath": "tsconfig.app.json"  // Specify custom tsconfig file
      }
    ]
  }
}
```

## Backward Compatibility

- When `tsconfigPath` option is not specified, existing behavior (defaults to `tsconfig.json`) is maintained
- All existing tests pass

## Additional Notes

This change enables projects using multiple `tsconfig.json` files to specify the appropriate configuration file for ESLint rules.