### PR TITLE
chore: add minimum permissions to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   jest:
     name: Jest


### PR DESCRIPTION
## Summary

ワークフローごとの最小 `permissions:` ブロックを追加します。

## Changes

- `.github/workflows/ci.yml`: `permissions: { contents: read }` を追加 (`actions/checkout` のため)

## Test plan

- [ ] CI が通ること