### PR TITLE
chore: deny lifecycle scripts via .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+ignore-scripts=true
+save-exact=true


### PR DESCRIPTION
## Summary

### What

`.npmrc` (新規): `ignore-scripts=true` + `save-exact=true` — install 時の lifecycle script を block する kill switch

### Why

本 repo は yarn classic (lockfile v1) を使っており、 `.npmrc` を読む経路でカバー可能。 (yarn berry でないため `.yarnrc.yml#enableScripts` は不要。)