### PR TITLE
Support ESLint v10: use context.filename instead of removed context.getFilename()

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -109,6 +109,20 @@ describe('create.ImportDeclaration', () => {
     expect(report).not.toBeCalled()
   })
 
+  it('should use context.filename when getFilename is unavailable (ESLint v10)', () => {
+    // ESLint v10 では context.getFilename() が削除され context.filename のみ利用可能
+    resolveImportPath.mockReturnValue('src/components/ui/Text')
+    const report = jest.fn()
+    const {ImportDeclaration: checkImport} = create({
+      options: [[]],
+      filename: path.join(process.cwd(), 'src/components/aaa/bbb.ts'),
+      report,
+    })
+
+    expect(() => checkImport(mockImportDeclaration)).not.toThrow()
+    expect(report).not.toBeCalled()
+  })
+
   it('should do nothing if not matched with importPath', () => {
     // importPath: src/components/ui/Text
     // dependency.module: src/libs

--- a/strict-dependencies/index.js
+++ b/strict-dependencies/index.js
@@ -67,7 +67,9 @@ module.exports = {
     const pathIndexMap = options.pathIndexMap ? options.pathIndexMap : {}
 
     function checkImport(node) {
-      const fileFullPath = context.getFilename()
+      // ESLint v9以降は context.filename を使用する。context.getFilename() は非推奨で ESLint v10 で削除されたため、
+      // 互換性のため context.filename が無い古いバージョンでは context.getFilename() にフォールバックする
+      const fileFullPath = context.filename ?? context.getFilename()
       const relativeFilePath = normalize(path.relative(process.cwd(), fileFullPath))
       const importPath = resolveImportPath(node.source.value, resolveRelativeImport ? relativeFilePath : null, pathIndexMap)
 


### PR DESCRIPTION
## Problem

ESLint v10 [removed the deprecated `context.getFilename()`](https://eslint.org/docs/latest/use/migrate-to-10.0.0) (along with other legacy `RuleContext` methods).

`strict-dependencies/index.js` calls `context.getFilename()` directly, so the rule throws `TypeError: context.getFilename is not a function` on every lint run under ESLint v10, making the plugin unusable on v10.

## Fix

Use `context.filename` (available since ESLint v8.40) and fall back to `context.getFilename()` for older versions:

```js
const fileFullPath = context.filename ?? context.getFilename()
```

This keeps full backward compatibility:

- ESLint < 8.40 (no `context.filename`) → falls back to `context.getFilename()`
- ESLint 8.40 – 9.x → uses `context.filename` (`getFilename()` still works but is deprecated)
- ESLint 10.x → uses `context.filename` (`getFilename()` removed)

## Test

- Added a test verifying the rule works when `context.getFilename` is absent (the ESLint v10 case), i.e. only `context.filename` is provided.
- All existing tests pass unchanged — their mock context provides `getFilename` but not `filename`, so the fallback path is still exercised.

`npm test` → 35 passed.