### PR TITLE
fix: support ESLint 10 by using context.filename with getFilename() fallback

### DIFF
--- a/strict-dependencies/index.js
+++ b/strict-dependencies/index.js
@@ -67,7 +67,7 @@ module.exports = {
     const pathIndexMap = options.pathIndexMap ? options.pathIndexMap : {}
 
     function checkImport(node) {
-      const fileFullPath = context.getFilename()
+      const fileFullPath = context.filename ?? context.getFilename()
       const relativeFilePath = normalize(path.relative(process.cwd(), fileFullPath))
       const importPath = resolveImportPath(node.source.value, resolveRelativeImport ? relativeFilePath : null, pathIndexMap)
 


### PR DESCRIPTION
## Problem

ESLint 10 removed the long-deprecated `context.getFilename()` method. As a result, `strict-dependencies` crashes at rule execution time on ESLint 10:

```
TypeError: context.getFilename is not a function
Occurred while linting <file>
Rule: "strictDependencies/strict-dependencies"
    at checkImport (.../strict-dependencies/index.js:70:36)
```

## Fix

Use `context.filename` (available since ESLint 8.40) when present, falling back to `context.getFilename()` for older ESLint versions:

```js
const fileFullPath = context.filename ?? context.getFilename()
```

This is the only usage of a removed ESLint 10 context API in the plugin (checked against `getFilename` / `getSourceCode` / `getScope` / `getAncestors` / `getPhysicalFilename` / `getCwd` / `parserOptions`), so this one-line change restores ESLint 10 compatibility.

## Testing

- `yarn test`: 34/34 passed
- Verified on a large monorepo (ESLint 10.7.0): the rule executes and reports violations correctly with this patch applied (we currently ship it via `pnpm patch` and would love to drop the patch once this lands 🙏)