### PR TITLE
fix: resolve tsconfig paths correctly when baseUrl is absent / baseUrl未指定時のtsconfig pathsの解決を修正

### DIFF
--- a/__tests__/resolveImportPath.js
+++ b/__tests__/resolveImportPath.js
@@ -79,6 +79,27 @@ describe('resolveImportPath', () => {
     })
   })
 
+  describe('should resolve tsconfig paths without baseUrl', () => {
+    [
+      ['@/components/', './components/', 'components/aaa/bbb'],
+      ['@/components', './components', 'components/aaa/bbb'],
+      ['@/components/*', './components/*', 'components/aaa/bbb'],
+    ].forEach(([target, resolve, expected]) => {
+      it(`${target}: [${resolve}]`, () => {
+        readFileSync.mockReturnValue(JSON.stringify({
+          compilerOptions: {
+            paths: {
+              [target]: [resolve],
+            },
+          },
+        }))
+
+        expect(resolveImportPath('components/aaa/bbb', null, {})).toBe('components/aaa/bbb')
+        expect(resolveImportPath('@/components/aaa/bbb', null, {})).toBe(expected)
+      })
+    })
+  })
+
   describe('resolveImportPath with pathIndexMap parameter', () => {
     const tsConfigWithMultiplePaths = JSON.stringify({
       compilerOptions: {

--- a/strict-dependencies/resolveImportPath.js
+++ b/strict-dependencies/resolveImportPath.js
@@ -23,7 +23,8 @@ module.exports = (importPath, relativeFilePath, pathIndexMap) => {
         // MEMO: pathIndexMapの指定がない場合 or 指定されているindexにアクセスしても値が得られない場合は[0]固定
         const pathIndex = matchedKey ? pathIndexMap[matchedKey] : 0
         const pathValue = tsConfig.compilerOptions.paths[key][pathIndex] ? tsConfig.compilerOptions.paths[key][pathIndex] : tsConfig.compilerOptions.paths[key][0]
-        importAliasMap[key] = tsConfig.compilerOptions.baseUrl ? path.join(tsConfig.compilerOptions.baseUrl, pathValue) : pathValue
+        // MEMO: TypeScript 7でbaseUrlが廃止されたため、baseUrl未指定時はtsconfig.jsonの場所(=baseUrl: ".")からの相対パスとして扱う
+        importAliasMap[key] = path.join(tsConfig.compilerOptions.baseUrl || '.', pathValue)
       })
     }
   } catch (e) {


### PR DESCRIPTION
TypeScript 7以降に対応するための提案になります。よろしくお願いします！

## 背景

- tsconfigにおいて、TypeScript 6.0 で `baseUrl` が非推奨化され、TypeScript 7.0 では完全に廃止されるため、`paths` は `baseUrl` なしで書く必要があります。
- `resolveImportPath.js` の現状の実装では、解決後のエイリアスに `./` が残ります。例: `@/domains/foo` → `./src/domains/foo`
- `.eslintrc` の `module` 設定では `./` 無しで書くため、`./` で解決されたものとマッチせず、該当エイリアスを使うimportに対してルールが機能しなくなっていました。

**具体的な再現例:**

```json
// tsconfig.json
{
  "compilerOptions": {
    "paths": { "@/*": ["./src/*"] }
  }
}
```

```js
// .eslintrc: src/domains/payment 配下からしかimportを許可しない設定
"strict-dependencies/strict-dependencies": ["error",
  [{ "module": "src/domains/payment", "allowReferenceFrom": ["src/domains/payment"] }]
]
```

```ts
// 本来は違反として検出されるべきimport
// src/pages/checkout.tsx
import { chargeCard } from '@/domains/payment/chargeCard'
```

`paths` の値に付いた `./` のせいで、このimportは `./src/domains/payment/chargeCard` と解決されます。
`module` の `isMatch` は `startsWith` で判定しますが、`"./src/..."` は `"src/domains/payment"` で始まらないため `false` となり、違反として報告されませんでした。

## 対応

- baseUrl 未指定時のデフォルトを "." とし、値が必ず path.join を通るようにしました。
```
path.join('.', './src/*')  // → 'src/*'   ./ が正規化され、module 設定とマッチするようになる
path.join('.', 'src/*')    // → 'src/*'   ./ を持たない既存の値は変化しない
```
./ は path.join が落とすため、解決結果が module 設定と同じ形式に揃います。./ のない既存の設定は結果が変わりません。

## テスト

`baseUrl` なしで `paths` の値に `./` が付くケースを追加しました。

## 相談
コメントとして相談を記載しております！ご確認よろしくお願いします。
https://github.com/knowledge-work/eslint-plugin-strict-dependencies/pull/198#discussion_r3718273680
